### PR TITLE
Added troubleshooting tip

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Non-official realization of SonarLint for VS Code.
 `sonarlint` utility will be downloaded (~30MB) on first-time activation of the extension.  
 If you are working behind a proxy, consider set `http_proxy` or `https_proxy` env variables and/or `http.proxy` and `http.proxyStrictSSL` settings in your Visual Studio Code.
 
+If the `SonarQube` commands dont show up in your VS Code after installing the extensions, try restarting your IDE. 
+
 ## TLDR: Quick Setup for Standalone mode
 
 * Just open your project dir


### PR DESCRIPTION
Update documentation to troubleshoot  SonarQube commands not being executable initially after installing the extension.